### PR TITLE
Lowering the memory consumption of `fitDTU.R`

### DIFF
--- a/R/fitDTU.R
+++ b/R/fitDTU.R
@@ -22,7 +22,7 @@
   otherCount <- totalCount-mat
   
   models_gene <- lapply(seq_len(nrow(mat)), function(i){
-    countsAll <- cbind(countData[i,], otherCount[i,])
+    countsAll <- cbind(mat[i,], otherCount[i,])
     drop <- rowSums(countsAll) == 0 ## gene count is zero in this cell
     countsAll <- countsAll + 1
     countsAll[drop, ] <- NA
@@ -121,6 +121,7 @@
   stopifnot(length(geneForEachTx) == nrow(countData))
   
   # split (sparse) matrix in a per-gene list of (sparse) matrices
+  colnames(countData) <- NULL # to avoid having colnames in each sub-matrix
   matList <- split.data.frame(countData, geneForEachTx)
   
   # Fit the models
@@ -148,6 +149,7 @@
   
   names(models) <- NULL
   models <- unlist(models)
+  models <- models[match(rownames(countData), names(models))]
   
   # Squeeze a set of sample variances together 
   # by computing empirical Bayes posterior means


### PR DESCRIPTION
Enhancement to `fitDTU.R`, the quasibinomial GLM fitting function of `satuRn`.
This enhancement lowers the total and peak memory usage of the fitting function, which allows for running satuRn on larger datasets. **Note that this enhancement does not change any of the `satuRn` results.**

The original implementation generated a dense matrix for the counts and a dense matrix of "other counts", i.e., the counts going to all the other features within the same gene. As such, even if the input was sparse, at 1 point in time both a dense matrix of counts and a dense matrix of "other counts" will be present, which is a heavy memory load.

Here, we first split the counts matrix (dense or sparse, depending on the input) in a list of matrices (dense or sparse), where each list element is a count matrix for each feature of a single gene. Next, we loop over these partial matrices, converting those on the fly to dense matrices, and then compute the "other counts" for only the features within that gene. Hence, at 1 point in time, only a small part of the "other counts" matrix is present, and if the input is a sparse matrix, only a small part is converted to a dense matrix.